### PR TITLE
make splice/sendfile write available again

### DIFF
--- a/fs/nilfs2/file.c
+++ b/fs/nilfs2/file.c
@@ -141,6 +141,7 @@ const struct file_operations nilfs_file_operations = {
 	/* .release	= nilfs_release_file, */
 	.fsync		= nilfs_sync_file,
 	.splice_read	= generic_file_splice_read,
+	.splice_write	= iter_file_splice_write,
 };
 
 const struct inode_operations nilfs_file_inode_operations = {


### PR DESCRIPTION
This was broken in 5.10 - you might find further information via this commit: [14e3e989f6a5d9646b6cf60690499cc8bdc11f7d](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?&id=14e3e989f6a5d9646b6cf60690499cc8bdc11f7d).

With this patch, writing to NILFS2 with `splice()`, or indirectly via `sendfile()`, works again.

Thanks and regards,
Jo.